### PR TITLE
fix: force nodejs 12

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,7 @@ from = "/*"
 to = "/.netlify/builders/screenshot"
 status = 200
 force = true
+
+[build.environment]
+NODE_VERSION = "12"
+AWS_LAMBDA_JS_RUNTIME = "nodejs12.x"

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,5 +8,4 @@ status = 200
 force = true
 
 [build.environment]
-NODE_VERSION = "12"
 AWS_LAMBDA_JS_RUNTIME = "nodejs12.x"


### PR DESCRIPTION
I couldn't make this repo run by default on Netlify without downgrading Node.js versions.

14/16 didn't work, but 12 worked

I suggest specifying a version so that others trying to deploy it do not have to figure things out

Related:
- https://stackoverflow.com/questions/66214552/tmp-chromium-error-while-loading-shared-libraries-libnss3-so-cannot-open-sha/67117619#67117619
- https://answers.netlify.com/t/lambda-function-failing-in-netlify-build-20-3-1/48900
- https://answers.netlify.com/t/chrome-aws-lambda-stopped-working-possibly-due-to-different-version-of-netlify-build/48847