### PR TITLE
Enable puppeteer and Chromium to work with latest versions of Node.

### DIFF
--- a/functions/screenshot.js
+++ b/functions/screenshot.js
@@ -1,5 +1,6 @@
 const { builder } = require("@netlify/functions");
-const chromium = require("chrome-aws-lambda");
+const chromium = require("@sparticuz/chromium");
+const puppeteer = require("puppeteer-core");
 
 function isFullUrl(url) {
   try {
@@ -15,7 +16,7 @@ async function screenshot(url, { format, viewport, dpr = 1, withJs = true, wait,
   // Must be between 3000 and 8500
   timeout = Math.min(Math.max(timeout, 3000), 8500);
 
-  const browser = await chromium.puppeteer.launch({
+  const browser = await puppeteer.launch({
     executablePath: await chromium.executablePath,
     args: chromium.args,
     defaultViewport: {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/11ty/api-screenshot#readme",
   "dependencies": {
     "@netlify/functions": "^1.0.0",
-    "chrome-aws-lambda": "^10.1.0",
-    "puppeteer-core": "^10.1.0"
+    "@sparticuz/chromium": "^108.0.0",
+    "puppeteer-core": "^19.2.2"
   }
 }


### PR DESCRIPTION
Update puppeteer-core and replace chrome-aws-lambda with @sparticuz/chromium

The current code will only work with Node 12, meaning it can't be deployed out of the box as Netlify uses Node 16.

The `chrome-aws-lambda` package hasn't been maintained in over a year, https://github.com/sparticuz/chromium is an alternative that provides the same functionality.

This is now able to be auto-deployed by Netlify and run out-of-the-box again

Sources:
* https://answers.netlify.com/t/netlify-cli-dropping-support-for-node-js-version-12/75130