### PR TITLE
Update to work on Node LTS 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 package-lock.json
 tmp
+# Local Netlify folder
+.netlify

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Read the [Blog post: Building an Automated Screenshot Service on Netlify in ~140
 <a href="https://app.netlify.com/start/deploy?repository=https://github.com/11ty/api-screenshot
 "><img src="https://www.netlify.com/img/deploy/button.svg" border="0" alt="Deploy to Netlify"></a>
 
-* You will _need_ to set an environment variable in the Netlify App UI `AWS_LAMBDA_JS_RUNTIME` with the value `nodejs12.x`. Read more at [Issue #17](https://github.com/11ty/api-screenshot/issues/17).
-
 ## Usage
 
 Image URLs have the formats:

--- a/functions/screenshot.js
+++ b/functions/screenshot.js
@@ -1,11 +1,12 @@
 const { builder } = require("@netlify/functions");
-const chromium = require("chrome-aws-lambda");
+const chromium = require("@sparticuz/chromium");
+const puppeteer = require("puppeteer-core");
 
 function isFullUrl(url) {
   try {
     new URL(url);
     return true;
-  } catch(e) {
+  } catch (e) {
     // invalid url OR local path
     return false;
   }
@@ -15,110 +16,117 @@ async function screenshot(url, { format, viewport, dpr = 1, withJs = true, wait,
   // Must be between 3000 and 8500
   timeout = Math.min(Math.max(timeout, 3000), 8500);
 
-  const browser = await chromium.puppeteer.launch({
-    executablePath: await chromium.executablePath,
-    args: chromium.args,
-    defaultViewport: {
-      width: viewport[0],
-      height: viewport[1],
-      deviceScaleFactor: parseFloat(dpr),
-    },
-    headless: chromium.headless,
-  });
+  let browser;
+  try {
+    browser = await puppeteer.launch({
+      executablePath: await chromium.executablePath(),
+      args: chromium.args,
+      defaultViewport: {
+        width: viewport[0],
+        height: viewport[1],
+        deviceScaleFactor: parseFloat(dpr),
+      },
+      headless: chromium.headless,
+    });
 
-  const page = await browser.newPage();
+    const page = await browser.newPage();
 
-  if(!withJs) {
-    page.setJavaScriptEnabled(false);
-  }
-
-  let response = await Promise.race([
-    page.goto(url, {
-      waitUntil: wait || ["load"],
-      timeout,
-    }),
-    new Promise(resolve => {
-      setTimeout(() => {
-        resolve(false); // false is expected below
-      }, timeout - 1500); // we need time to execute the window.stop before the top level timeout hits
-    }),
-  ]);
-
-  if(response === false) { // timed out, resolved false
-    await page.evaluate(() => window.stop());
-  }
-
-  // let statusCode = response.status();
-  // TODO handle 4xx/5xx status codes better
-
-  let options = {
-    type: format,
-    encoding: "base64",
-    fullPage: false,
-    captureBeyondViewport: false,
-    clip: {
-      x: 0,
-      y: 0,
-      width: viewport[0],
-      height: viewport[1],
+    if (!withJs) {
+      page.setJavaScriptEnabled(false);
     }
-  };
 
-  if(format === "jpeg") {
-    options.quality = 80;
+    let response = await Promise.race([
+      page.goto(url, {
+        waitUntil: wait || ["load"],
+        timeout,
+      }),
+      new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(false); // false is expected below
+        }, timeout - 1500); // we need time to execute the window.stop before the top level timeout hits
+      }),
+    ]);
+
+    if (response === false) {
+      // timed out, resolved false
+      await page.evaluate(() => window.stop());
+    }
+
+    // let statusCode = response.status();
+    // TODO handle 4xx/5xx status codes better
+
+    let options = {
+      type: format,
+      encoding: "base64",
+      fullPage: false,
+      captureBeyondViewport: false,
+      clip: {
+        x: 0,
+        y: 0,
+        width: viewport[0],
+        height: viewport[1],
+      },
+    };
+
+    if (format === "jpeg") {
+      options.quality = 80;
+    }
+
+    let output = await page.screenshot(options);
+
+    await closeBrowser(browser);
+
+    return output;
+  } catch (error) {
+    await closeBrowser(browser);
+    throw error;
   }
-
-  let output = await page.screenshot(options);
-
-  await browser.close();
-
-  return output;
 }
 
 // Based on https://github.com/DavidWells/netlify-functions-workshop/blob/master/lessons-code-complete/use-cases/13-returning-dynamic-images/functions/return-image.js
 async function handler(event, context) {
   // e.g. /https%3A%2F%2Fwww.11ty.dev%2F/small/1:1/smaller/
-  let pathSplit = event.path.split("/").filter(entry => !!entry);
+  let pathSplit = event.path.split("/").filter((entry) => !!entry);
   let [url, size, aspectratio, zoom, cachebuster] = pathSplit;
   let format = "jpeg"; // hardcoded for now, but png and webp are supported!
   let viewport = [];
 
   // Manage your own frequency by using a _ prefix and then a hash buster string after your URL
   // e.g. /https%3A%2F%2Fwww.11ty.dev%2F/_20210802/ and set this to today’s date when you deploy
-  if(size && size.startsWith("_")) {
+  if (size && size.startsWith("_")) {
     cachebuster = size;
     size = undefined;
   }
-  if(aspectratio && aspectratio.startsWith("_")) {
+  if (aspectratio && aspectratio.startsWith("_")) {
     cachebuster = aspectratio;
     aspectratio = undefined;
   }
-  if(zoom && zoom.startsWith("_")) {
+  if (zoom && zoom.startsWith("_")) {
     cachebuster = zoom;
     zoom = undefined;
   }
 
   // Options
   let pathOptions = {};
-  let optionsMatch = (cachebuster || "").split("_").filter(entry => !!entry);
-  for(let o of optionsMatch) {
+  let optionsMatch = (cachebuster || "").split("_").filter((entry) => !!entry);
+  for (let o of optionsMatch) {
     let [key, value] = o.split(":");
     pathOptions[key.toLowerCase()] = parseInt(value, 10);
   }
 
   let wait = ["load"];
-  if(pathOptions.wait === 0) {
+  if (pathOptions.wait === 0) {
     wait = ["domcontentloaded"];
-  } else if(pathOptions.wait === 1) {
+  } else if (pathOptions.wait === 1) {
     wait = ["load"];
-  } else if(pathOptions.wait === 2) {
+  } else if (pathOptions.wait === 2) {
     wait = ["load", "networkidle0"];
-  } else if(pathOptions.wait === 3) {
+  } else if (pathOptions.wait === 3) {
     wait = ["load", "networkidle2"];
   }
 
   let timeout;
-  if(pathOptions.timeout) {
+  if (pathOptions.timeout) {
     timeout = pathOptions.timeout * 1000;
   }
 
@@ -129,37 +137,39 @@ async function handler(event, context) {
   zoom = zoom || "standard";
 
   let dpr;
-  if(zoom === "bigger") {
+  if (zoom === "bigger") {
     dpr = 1.4;
-  } else if(zoom === "smaller") {
+  } else if (zoom === "smaller") {
     dpr = 0.71428571;
-  } else if(zoom === "standard") {
+  } else if (zoom === "standard") {
     dpr = 1;
   }
 
-  if(size === "small") {
-    if(aspectratio === "1:1") {
+  if (size === "small") {
+    if (aspectratio === "1:1") {
       viewport = [375, 375];
-    } else if(aspectratio === "9:16") {
+    } else if (aspectratio === "9:16") {
       viewport = [375, 667];
     }
-  } else if(size === "medium") {
-    if(aspectratio === "1:1") {
+  } else if (size === "medium") {
+    if (aspectratio === "1:1") {
       viewport = [650, 650];
-    } else if(aspectratio === "9:16") {
+    } else if (aspectratio === "9:16") {
       viewport = [650, 1156];
     }
-  } else if(size === "large") {
+  } else if (size === "large") {
     // 0.5625 aspect ratio not supported on large
-    if(aspectratio === "1:1") {
+    if (aspectratio === "1:1") {
       viewport = [1024, 1024];
     }
-  } else if(size === "opengraph") {
+  } else if (size === "opengraph") {
     // ignores aspectratio
     // always maintain a 1200×630 output image
-    if(zoom === "bigger") { // dpr = 1.4
+    if (zoom === "bigger") {
+      // dpr = 1.4
       viewport = [857, 450];
-    } else if(zoom === "smaller") { // dpr = 0.714
+    } else if (zoom === "smaller") {
+      // dpr = 0.714
       viewport = [1680, 882];
     } else {
       viewport = [1200, 630];
@@ -169,12 +179,14 @@ async function handler(event, context) {
   url = decodeURIComponent(url);
 
   try {
-    if(!isFullUrl(url)) {
+    if (!isFullUrl(url)) {
       throw new Error(`Invalid \`url\`: ${url}`);
     }
 
-    if(!viewport || viewport.length !== 2) {
-      throw new Error("Incorrect API usage. Expects one of: /:url/ or /:url/:size/ or /:url/:size/:aspectratio/")
+    if (!viewport || viewport.length !== 2) {
+      throw new Error(
+        "Incorrect API usage. Expects one of: /:url/ or /:url/:size/ or /:url/:size/:aspectratio/"
+      );
     }
 
     let output = await screenshot(url, {
@@ -191,10 +203,10 @@ async function handler(event, context) {
     return {
       statusCode: 200,
       headers: {
-        "content-type": `image/${format}`
+        "content-type": `image/${format}`,
       },
       body: output,
-      isBase64Encoded: true
+      isBase64Encoded: true,
     };
   } catch (error) {
     console.log("Error", error);
@@ -207,12 +219,22 @@ async function handler(event, context) {
       ttl: 3600,
       headers: {
         "content-type": "image/svg+xml",
-        "x-error-message": error.message
+        "x-error-message": error.message,
       },
       body: `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="${viewport[0]}" height="${viewport[1]}" x="0" y="0" viewBox="0 0 1569.4 2186" xml:space="preserve" aria-hidden="true" focusable="false"><style>.st0{fill:#bbb;stroke:#bbb;stroke-width:28;stroke-miterlimit:10}</style><g><path class="st0" d="M562.2 1410.1c-9 0-13.5-12-13.5-36.1V778.9c0-11.5-2.3-16.9-7-16.2-28.4 7.2-42.7 10.8-43.1 10.8-7.9.7-11.8-7.2-11.8-23.7v-51.7c0-14.3 4.3-22.4 12.9-24.2l142.2-36.6c1.1-.3 2.7-.5 4.8-.5 7.9 0 11.8 8.4 11.8 25.3v712c0 24.1-4.7 36.1-14 36.1l-82.3-.1zM930.5 1411.2c-14.4 0-26.8-1-37.4-3-10.6-2-21.6-6.5-33.1-13.5s-20.9-16.6-28.3-28.8-13.4-29.3-18-51.2-7-47.9-7-78.1V960.4c0-7.2-2-10.8-5.9-10.8h-33.4c-9 0-13.5-8.6-13.5-25.8v-29.1c0-17.6 4.5-26.4 13.5-26.4h33.4c3.9 0 5.9-4.8 5.9-14.5l9.7-209.5c1.1-19 5.7-28.5 14-28.5h53.9c9 0 13.5 9.5 13.5 28.5v209.5c0 9.7 2.1 14.5 6.5 14.5H973c9 0 13.5 8.8 13.5 26.4v29.1c0 17.2-4.5 25.8-13.5 25.8h-68.9c-2.5 0-4.2.6-5.1 1.9-.9 1.2-1.3 4.2-1.3 8.9v277.9c0 20.8 1.3 38.2 4 52s6.6 24 11.8 30.4 10.4 10.8 15.6 12.9c5.2 2.2 11.6 3.2 19.1 3.2h38.2c9.7 0 14.5 6.7 14.5 19.9v32.3c0 14.7-5.2 22.1-15.6 22.1l-54.8.1zM1137.2 1475.8c8.2 0 15.4-6.7 21.5-20.2s9.2-32.6 9.2-57.4c0-5.8-3.6-25.7-10.8-59.8l-105.6-438.9c-.7-5-1.1-9-1.1-11.9 0-12.9 2.7-19.4 8.1-19.4h65.2c5 0 9.1 1.7 12.4 5.1s5.8 10.3 7.5 20.7l70 370.5c1.4 4.3 2.3 6.5 2.7 6.5 1.4 0 2.2-2 2.2-5.9l54.9-369.5c1.4-10.8 3.7-18 6.7-21.8s6.9-5.7 11.6-5.7h45.2c6.1 0 9.2 7 9.2 21 0 3.2-.4 7.4-1.1 12.4l-95.9 499.3c-7.5 41.3-15.8 72.9-24.8 94.8s-19 36.8-30.2 44.7c-11.1 7.9-25.8 12-44.2 12.4h-5.4c-29.1 0-48.8-7.7-59.2-23.2-2.9-3.2-4.3-11.5-4.3-24.8 0-26.6 4.3-39.9 12.9-39.9.7 0 7.2 1.8 19.4 5.4 12.4 3.8 20.3 5.6 23.9 5.6z"/><g><path class="st0" d="M291.2 1411.1c-9 0-13.5-12-13.5-36.1V779.9c0-11.5-2.3-16.9-7-16.2-28.4 7.2-42.7 10.8-43.1 10.8-7.9.7-11.8-7.2-11.8-23.7v-51.7c0-14.3 4.3-22.4 12.9-24.2L371 638.2c1.1-.3 2.7-.5 4.8-.5 7.9 0 11.8 8.4 11.8 25.3v712c0 24.1-4.7 36.1-14 36.1h-82.4z"/></g></g></svg>`,
       isBase64Encoded: false,
     };
   }
+}
+
+async function closeBrowser(browser) {
+  // https://github.com/Sparticuz/chromium?tab=readme-ov-file#im-experiencing-timeouts-or-failures-closing-chromium
+  for (const page of await browser.pages()) {
+    await page.close({
+      runBeforeUnload: true,
+    });
+  }
+  await Promise.race([browser.close(), browser.close(), browser.close()]);
 }
 
 exports.handler = builder(handler);

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,13 @@
+[build.environment]
+NODE_VERSION = "20"
+AWS_LAMBDA_JS_RUNTIME = "nodejs20.x"
+
 [functions]
 directory = "functions"
+external_node_modules = ["@sparticuz/chromium"] # https://github.com/Sparticuz/chromium/issues/24#issuecomment-1414107620
 
 [[redirects]]
 from = "/*"
-to = "/.netlify/builders/screenshot"
+to = "/.netlify/functions/screenshot"
 status = 200
 force = true
-
-# The screenshot function requires an environment variable `AWS_LAMBDA_JS_RUNTIME` to be set to `nodejs12.x` in the Netlify UI
-# Read more: https://github.com/11ty/api-screenshot/issues/17

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/11ty/api-screenshot#readme",
   "dependencies": {
-    "@netlify/functions": "^1.0.0",
-    "chrome-aws-lambda": "^10.1.0",
-    "puppeteer-core": "^10.1.0"
+    "@netlify/functions": "^2.8.1",
+    "@sparticuz/chromium": "^123.0.1",
+    "puppeteer-core": "^22.6.4"
   }
 }


### PR DESCRIPTION
Addresses the issues discussed in #17.

I tried running @LewisDaleUK's PR (#14) which attempts the same thing but had a few issues for me (bundle size and timeouts).

As in the previous PR this updates `puppeteer-core` and replaces `chrome-aws-lambda` with `@sparticuz/chromium` and additionally:

* Configures the function to treat `@sparticuz/chromium` as an external module (see https://github.com/Sparticuz/chromium/issues/24#issuecomment-1414107620)
* Adds some extra logic to ensure that Chromium correctly closes all pages and always shuts down the browser (see https://github.com/Sparticuz/chromium?tab=readme-ov-file#im-experiencing-timeouts-or-failures-closing-chromium)

Which from my testing fixes the bundle size and other issues in #14.

---

**Example screenshot** (from my instance running on Netlify): https://11ty-api-screenshot-fix.netlify.app/https%3A%2F%2Fwww.11ty.dev%2Fdocs%2F/small/9:16/bigger/
